### PR TITLE
Added new README section and 2 important env vars for ElasticSearch.

### DIFF
--- a/zammad/README.md
+++ b/zammad/README.md
@@ -1,6 +1,6 @@
 # Zammad Helm Chart
 
-This directory contains a Kubernetes chart to deploy Zammad ticket system
+This directory contains a Kubernetes chart to deploy [Zammad](https://zammad.org/) ticket system.
 
 
 ## Prerequisites Details
@@ -32,33 +32,33 @@ The following table lists the configurable parameters of the zammad chart and th
 
 |             Parameter             |              Description                 |               Default               |
 |-----------------------------------|------------------------------------------|-------------------------------------|
-| `useElasticsearch`                | use Elasticsearch dependcy               | `true`                              |
-| `useMemcached`                    | use Memcached dependency                 | `true`                              |
-| `usePostgresql`                   | use PostgreSQL dependency                | `true`                              |
+| `useElasticsearch`                | Use Elasticsearch dependency               | `true`                              |
+| `useMemcached`                    | Use Memcached dependency                 | `true`                              |
+| `usePostgresql`                   | Use PostgreSQL dependency                | `true`                              |
 | `image.repository`                | Container image to use                   | `zammad/zammad-docker-compose`      |
 | `image.tag`                       | Container image tag to deploy            | `2.8.0-22`                          |
 | `image.pullPolicy`                | Container pull policy                    | `IfNotPresent`                      |
 | `service.type`                    | Service type                             | `ClusterIP`                         |
 | `service.port`                    | Service port                             | `80`                                |
-| `ingress.enabled`                 | enable Ingress                           | `false`                             |
+| `ingress.enabled`                 | Enable Ingress                           | `false`                             |
 | `ingress.annotations`             | Additional ingress annotations           | ``                                  |
 | `ingress.path`                    | Ingress path                             | ``                                  |
 | `ingress.hosts`                   | Ingress hosts                            | ``                                  |
 | `ingress.tls`                     | Ingress TLS                              | `[]`                                |
 | `env`                             | Environment variables                    | `See values.yaml`                   |
-| `persistance.enabled`             | Enable persistance                       | `true`                              |
-| `persistance.accessMode`          | Access mode                              | `ReadWriteOnce`                     |
-| `persistance.size                 | Volume size                              | `15Gi`                              |
-| `resources.nginx`                 | Resource usage of Zammads nginx          | `{}`                                |
-| `resources.railsserver`           | Resource usage of Zammads railsserver    | `{}`                                |
-| `resources.scheduler`             | Resource usage of Zammads scheduler      | `{}`                                |
-| `resources.websocket`             | Resource usage of Zammads websocket      | `{}`                                |
-| `nodeSelector`                    | nodeSelector                             | `{}`                                |
+| `persistence.enabled`             | Enable persistence                       | `true`                              |
+| `persistence.accessMode`          | Access mode                              | `ReadWriteOnce`                     |
+| `persistence.size`                 | Volume size                              | `15Gi`                              |
+| `resources.nginx`                 | Resource usage of Zammad's nginx container          | `{}`                                |
+| `resources.railsserver`           | Resource usage of Zammad's railsserver container    | `{}`                                |
+| `resources.scheduler`             | Resource usage of Zammad's scheduler container      | `{}`                                |
+| `resources.websocket`             | Resource usage of Zammad's websocket container      | `{}`                                |
+| `nodeSelector`                    | Node Selector                             | `{}`                                |
 | `tolerations`                     | Tolerations                              | `[]`                                |
-| `affinity`                        | affinity                                 | `{}`                                |
+| `affinity`                        | Affinity                                 | `{}`                                |
 | `elasticsearch.image.repository`  | Elasticsearch image repo                 | `zammad/zammad-docker-compose`      |
 | `elasticsearch.image.tag`         | Elasticsearch image tag                  | `zammad-elasticsearch-2.8.0-22`     |
-| `elasticsearch.cluster.xpackEnable` | Elasticsearch Xpack option             | `false`                             |
+| `elasticsearch.cluster.xpackEnable` | Enable Elasticsearch Xpack option             | `false`                             |
 | `elasticsearch.cluster.env`       | Elasticsearch environment variables      | ``                                  |
 | `elasticsearch.client.replicas`   | Elasticsearch client replicas            | `1`                                 |
 | `elasticsearch.data.terminationGracePeriodSeconds` | Elasticsearch termination Grace Period | `60`                 |
@@ -72,6 +72,23 @@ The following table lists the configurable parameters of the zammad chart and th
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
+### Properly configuring Elasticsearch
+The default **elasticsearch.yml** set by the Elasticsearch chart expects 2 masters.  If using just 1 master replica, there are 3 environment variables which should be set equally to avoid issues starting Elasticsearch.
+
+Set the following environment variables under **elasticsearch.cluster.env**.  The Zammad StatefulSet will most likely fail without setting these correctly.
+
+Refer to the Elasticsearch documentation for info on these variables.  [[1](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-gateway.html)] [[2](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-node.html#split-brain)]
+
+```yaml
+elasticsearch:
+  cluster:
+    env:
+      EXPECTED_MASTER_NODES: "1"
+      MINIMUM_MASTER_NODES: "1"
+      RECOVER_AFTER_MASTER_NODES: "1"
+  master:
+    replicas: 1
+```
 
 ## Using zammad
 

--- a/zammad/values.yaml
+++ b/zammad/values.yaml
@@ -107,8 +107,11 @@ elasticsearch:
     tag: "zammad-elasticsearch-2.8.0-22"
   cluster:
     xpackEnable: false
+    # See README for proper configuration
     env:
+      EXPECTED_MASTER_NODES: "1"
       MINIMUM_MASTER_NODES: "1"
+      RECOVER_AFTER_MASTER_NODES: "1"
       XPACK_MONITORING_ENABLED: false
   client:
     replicas: 1


### PR DESCRIPTION
#### What this PR does / why we need it:
The **README** and **values.yaml** both specify the default replica count for ElasticSearch master as **1**.  However, the default **elasticsearch.yml** used by the Elasticsearch chart (found in the ConfigMap for Elasticsearch) has two environment variables set up for a configuration of 2 master replicas.  This causes an error if using the default recommended value in this repository (1).  The Zammad StatefulSet won't get past the **zammad-init** container due to this error.

**EXPECTED_MASTER_NODES** and **RECOVER_AFTER_MASTER_NODES** are the new variables.

```yaml
elasticsearch:
  cluster:
    env:
      EXPECTED_MASTER_NODES: "1"
      MINIMUM_MASTER_NODES: "1"
      RECOVER_AFTER_MASTER_NODES: "1"
  master:
    replicas: 1
```

I included an explanation in the README to provide some context and make users of this chart aware of how to configure ElasticSearch properly.  Two links are included for the Elasticsearch documentation to make the configuration experience less of a hassle.  In addition, I found some typos and inconsistent capitalizations in the README and corrected them.

The environment variables mentioned above in the README were also added to **values.yaml**.

#### Which issue this PR fixes
  - No issue was made for this.

#### Special notes for your reviewer:
Chart version is untouched in this PR since I have another PR to make.  Hopefully this helps others and prevents them from scratching their heads in confusion for a few days!

#### Checklist
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
